### PR TITLE
Add collapsible preview pane

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -109,3 +109,13 @@
     border-radius: 4px;
     margin-bottom: 10px;
 }
+
+/* Preview pane styles */
+.preview-pane {
+    border-left: 1px solid #ddd;
+    padding-left: 1rem;
+}
+.loading-indicator {
+    text-align: center;
+    padding: 1rem;
+}

--- a/src/static/js/preview.js
+++ b/src/static/js/preview.js
@@ -1,0 +1,50 @@
+// Preview pane functionality
+
+document.addEventListener('DOMContentLoaded', () => {
+  const previewPane = document.getElementById('preview-pane');
+  const previewFrame = document.getElementById('preview-frame');
+  const toggleBtn = document.getElementById('toggle-preview-pane');
+  const closeBtn = document.getElementById('close-preview');
+  const loading = document.getElementById('preview-loading');
+
+  function setVisible(show) {
+    if (show) {
+      previewPane.classList.remove('hidden');
+      localStorage.setItem('previewPaneVisible', 'true');
+    } else {
+      previewPane.classList.add('hidden');
+      localStorage.setItem('previewPaneVisible', 'false');
+    }
+  }
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      setVisible(previewPane.classList.contains('hidden'));
+    });
+  }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => setVisible(false));
+  }
+
+  const stored = localStorage.getItem('previewPaneVisible');
+  if (stored === 'true') {
+    setVisible(true);
+  }
+
+  document.querySelectorAll('.preview-link').forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const url = link.getAttribute('data-preview-url');
+      if (!url) return;
+      setVisible(true);
+      loading.classList.remove('hidden');
+      previewFrame.classList.add('hidden');
+      previewFrame.onload = () => {
+        loading.classList.add('hidden');
+        previewFrame.classList.remove('hidden');
+      };
+      previewFrame.src = url;
+    });
+  });
+});

--- a/src/templates/explorer.html
+++ b/src/templates/explorer.html
@@ -76,10 +76,12 @@
                     <input type="hidden" name="sort" value="{{ sort_by }}">
                     <input type="hidden" name="desc" value="{{ 'true' if sort_desc else 'false' }}">
                 </form>
+                <button id="toggle-preview-pane" class="ml-4 px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Toggle Preview</button>
             </div>
         </div>
         
-        <div class="content-container">
+        <div class="content-wrapper flex">
+            <div class="content-container flex-1">
             <table class="table">
                 <thead>
                     <tr>
@@ -116,6 +118,7 @@
                         <td>
                             <span class="file-icon">📄</span>
                             <a href="{{ url_for('explore', path=file.path) }}" class="{{ 'text-blue-400 hover:text-blue-300' if theme == 'dark' else 'text-blue-600 hover:text-blue-800' }}">{{ file.name }}</a>
+                            <button class="ml-2 text-sm text-green-600 preview-link" data-preview-url="{{ get_preview_url(file.path) }}">Preview</button>
                         </td>
                         <td class="{{ 'text-gray-400' if theme == 'dark' else 'text-gray-500' }}">{{ file.modified }}</td>
                         <td class="{{ 'text-gray-400' if theme == 'dark' else 'text-gray-500' }}">
@@ -131,7 +134,7 @@
                         </td>
                     </tr>
                     {% endfor %}
-                    
+
                     {% if not dirs and not files %}
                     <tr>
                         <td colspan="3" class="text-center py-5 {{ 'text-gray-400' if theme == 'dark' else 'text-gray-500' }}">
@@ -145,6 +148,17 @@
                     {% endif %}
                 </tbody>
             </table>
+            </div>
+
+            <!-- Preview Pane -->
+            <div id="preview-pane" class="preview-pane hidden w-1/2 ml-4">
+                <div class="flex justify-between mb-2">
+                    <h3 class="font-semibold">Preview</h3>
+                    <button id="close-preview" class="text-red-500">&times;</button>
+                </div>
+                <div id="preview-loading" class="loading-indicator hidden">Loading...</div>
+                <iframe id="preview-frame" class="w-full h-full hidden"></iframe>
+            </div>
         </div>
     </div>
     
@@ -174,6 +188,7 @@
     </div>
     
     <script src="{{ url_for('static', filename='js/plugins.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/preview.js') }}"></script>
     
     <!-- Theme switcher script -->
     <script>


### PR DESCRIPTION
## Summary
- add preview pane toggled from explorer
- preview file via iframe with loading indicator
- store visibility state in localStorage

## Testing
- `pip install -e .[dev]` *(fails: Could not find a matching distribution)*
- `pytest -q` *(fails: command not found)*