### PR TITLE
Add file context menu

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -109,3 +109,33 @@
     border-radius: 4px;
     margin-bottom: 10px;
 }
+
+/* Context menu styles */
+#file-context-menu {
+    position: absolute;
+    z-index: 2000;
+    background: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+#file-context-menu li {
+    list-style: none;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+#file-context-menu li:hover {
+    background-color: #f0f0f0;
+}
+
+.theme-dark #file-context-menu {
+    background: #2d3748;
+    border-color: #4a5568;
+    color: #e2e8f0;
+}
+
+.theme-dark #file-context-menu li:hover {
+    background-color: #4a5568;
+}

--- a/src/static/js/plugins.js
+++ b/src/static/js/plugins.js
@@ -237,6 +237,54 @@ document.addEventListener('DOMContentLoaded', function() {
             copyToClipboard(textToCopy, event.target);
         }
     });
+
+    // Context menu for file actions
+    const contextMenu = document.getElementById('file-context-menu');
+    let contextFilePath = null;
+
+    document.querySelectorAll('tr.file-row').forEach(row => {
+        row.addEventListener('contextmenu', function(e) {
+            e.preventDefault();
+            contextFilePath = this.getAttribute('data-file-path');
+            contextMenu.style.top = `${e.pageY}px`;
+            contextMenu.style.left = `${e.pageX}px`;
+            contextMenu.classList.remove('hidden');
+        });
+    });
+
+    document.addEventListener('click', function(e) {
+        if (!contextMenu.contains(e.target)) {
+            contextMenu.classList.add('hidden');
+        }
+    });
+
+    contextMenu.addEventListener('click', function(e) {
+        const action = e.target.getAttribute('data-action');
+        if (!action) return;
+
+        if (action === 'open') {
+            window.open(`/preview/${encodeURIComponent(contextFilePath)}`, '_blank');
+        } else if (action === 'download') {
+            window.open(`/explore/${encodeURIComponent(contextFilePath)}`, '_blank');
+        } else if (action === 'copy') {
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(contextFilePath);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = contextFilePath;
+                textarea.style.position = 'fixed';
+                document.body.appendChild(textarea);
+                textarea.select();
+                try {
+                    document.execCommand('copy');
+                } finally {
+                    document.body.removeChild(textarea);
+                }
+            }
+        }
+
+        contextMenu.classList.add('hidden');
+    });
     
     // Function to show modal with content
     function showModal(title, content, isError = false, isHtml = false) {

--- a/src/templates/explorer.html
+++ b/src/templates/explorer.html
@@ -112,7 +112,7 @@
                     {% endfor %}
                     
                     {% for file in files %}
-                    <tr class="{{ 'hover:bg-gray-700' if theme == 'dark' else 'hover:bg-gray-50' }}">
+                    <tr class="{{ 'hover:bg-gray-700' if theme == 'dark' else 'hover:bg-gray-50' }} file-row" data-file-path="{{ file.path }}">
                         <td>
                             <span class="file-icon">📄</span>
                             <a href="{{ url_for('explore', path=file.path) }}" class="{{ 'text-blue-400 hover:text-blue-300' if theme == 'dark' else 'text-blue-600 hover:text-blue-800' }}">{{ file.name }}</a>
@@ -172,7 +172,14 @@
             </div>
         </div>
     </div>
-    
+
+    <!-- Context menu for file actions -->
+    <ul id="file-context-menu" class="context-menu hidden">
+        <li data-action="open">Open</li>
+        <li data-action="download">Download</li>
+        <li data-action="copy">Copy Path</li>
+    </ul>
+
     <script src="{{ url_for('static', filename='js/plugins.js') }}"></script>
     
     <!-- Theme switcher script -->


### PR DESCRIPTION
## Summary
- enable right-click file context menu to open/download/copy path
- style the context menu for light and dark themes
- wire up context menu behaviour in JS

## Testing
- `flake8 src tests` *(fails: command not found)*
- `mypy --python-version 3.8 src` *(fails: configuration requires >=3.8)*
- `pytest -q` *(fails: command not found)*